### PR TITLE
fix: get all types of banner images from notion

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,7 +3,12 @@ import svgLoader from 'vite-svg-loader'
 import { languageLocales } from './constants'
 
 export default defineNuxtConfig({
-  ssr: true,
+  routeRules: {
+    // Homepage pre-rendered at build time
+    '/': { prerender: true },
+    // calendar page generated on demand, revalidates in background, cached until API response changes
+    '/calendar': { swr: true },
+  },
   app: {
     baseURL: '/',
     head: {

--- a/server/api/data.ts
+++ b/server/api/data.ts
@@ -28,7 +28,7 @@ export default defineEventHandler(async (_event) => {
         return {
           id: page.id,
           title: properties.title?.title[0]?.plain_text || '',
-          bannerImage: properties.banner?.files[0]?.file?.url || '',
+          bannerImage: getImageUrl(properties.banner?.files[0]) || '',
           description: properties.description?.rich_text[0]?.plain_text || '',
           date: properties.date?.date?.start || '',
           url: properties.url?.url || '',
@@ -69,6 +69,23 @@ export default defineEventHandler(async (_event) => {
     }
   }
 })
+
+function getImageUrl(
+  file:
+    | { type: string; file: { url: string } }
+    | { type: string; external: { url: string } },
+) {
+  if ('file' in file) {
+    return file.file.url
+  } else if ('external' in file) {
+    return file.external.url
+  } else {
+    // unreachable, file_upload is only generated using the Notion API
+    // https://developers.notion.com/reference/file-object#file-uploads
+    console.error('Unknown file type:', JSON.stringify(file))
+    return ''
+  }
+}
 
 async function downloadImages(items: Array<{ bannerImage: string }>) {
   // Make sure the cache directory exists

--- a/server/api/data.ts
+++ b/server/api/data.ts
@@ -113,7 +113,9 @@ async function downloadImages(items: Array<{ bannerImage: string }>) {
             // Don't use fs.writeFileSync because it will block the event loop
             // and cause performance issues
             fs.writeFile(filePath, Buffer.from(arrayBuffer), {}, (err) => {
-              console.error('Error writing image to cache:', err)
+              if (err) {
+                console.error('Error writing image to cache:', err)
+              }
             })
             return `/api/image/${hash}${ext}`
           })


### PR DESCRIPTION
- [feat: add route rules for homepage and calendar page](https://github.com/witnet/website/commit/0de219e710ee7677a39849979d7ab2258c14063a)
- [fix: get all types of banner images from notion](https://github.com/witnet/website/commit/15c85d309696d72490edb6540cb6c97476eb51b3)
- [fix: improve error handling when writing images to cache](https://github.com/witnet/website/commit/d5e6e4e043ff00ca3b35eb0a59783dea39d905a6)